### PR TITLE
feat(llm-sdk): add support context for prompt for chain-specific connection

### DIFF
--- a/packages/llm/src/langchain/chaincontext.ts
+++ b/packages/llm/src/langchain/chaincontext.ts
@@ -1,0 +1,52 @@
+import { tool } from "@langchain/core/tools"
+import { z } from "zod"
+import { getNativeBalance, convertAddress } from "@polkadot-agent-kit/core"
+import { Api, KnowChainId, getAllSupportedChains, getChainByName } from "@polkadot-agent-kit/common"
+
+/**
+ * Enhances the tool to process prompts and dynamically switch between chains.
+ * @returns A tool that sets the chain context based on the provided chain name or ID in the prompt.
+ */
+export const checkBalanceTool = (
+    apis: Map<string, any>,
+    address: string
+) => {
+    return tool(
+        async ({ chainId, prompt }: { chainId?: string; prompt?: string }) => {
+            try {
+                let chain;
+                if (prompt) {
+                    const supportedChains = getAllSupportedChains();
+                    chain = supportedChains.find(c => prompt.toLowerCase().includes(c.name.toLowerCase()));
+                    if (!chain) {
+                        throw new Error(`No matching chain found in prompt: ${prompt}`);
+                    }
+                } else if (chainId) {
+                    chain = getChainById(chainId);
+                }
+
+                if (!chain) {
+                    throw new Error(`Chain not found. Provide a valid chainId or include chain details in the prompt.`);
+                }
+
+                return {
+                    content: `Current chain context set to ${chain.name}`,
+                    tool_call_id: `set_chain_context_${Date.now()}`
+                };
+            } catch (error) {
+                return {
+                    content: `Error setting chain context: ${error.message}`,
+                    tool_call_id: `set_chain_context_error_${Date.now()}`
+                };
+            }
+        },
+        {
+            name: "set_chain_context",
+            description: "Set the current blockchain context (chainId or prompt)",
+            schema: z.object({
+                chainId: z.string().optional().describe("The ID of the blockchain to set as context"),
+                prompt: z.string().optional().describe("A prompt containing chain-specific instructions")
+            })
+        }
+    );
+};

--- a/packages/sdk/src/api.ts
+++ b/packages/sdk/src/api.ts
@@ -67,6 +67,10 @@ export class PolkadotAgentKit implements IPolkadotApi, IPolkadotAgentApi {
     return this.agentApi.getNativeBalanceTool(address)
   }
 
+  getSetChainContextTool(): DynamicStructuredTool {
+    return this.agentApi.getSetChainContextTool()
+  }
+
   /**
    * Get Native Transfer Tool
    * Creates a tool for transferring native tokens to an address


### PR DESCRIPTION
### Description
Follow the issues https://github.com/elasticlabs-org/polkadot-agent-kit/issues/22 I have adding ```getSetChainContextTool```method to provides a dynamic way to set the blockchain context based on user input or prompts. It is part of the PolkadotAgentKit class and is designed to work seamlessly with LangChain tools.

With this PR AI Agent can can
- Dynamically switches the chain context based on the provided chain ID or instructions in a prompt.
- Handles errors gracefully when invalid or unsupported chain IDs are provided.
- Integrates with LangChain for advanced AI-driven workflows.

### Usage
Example: Switching Chain Context
```js
// Create an instance of PolkadotAgentKit
const agent = new PolkadotAgentKit(wallet, config);

// Get the chain context switching tool
const setChainContextTool = agent.getSetChainContextTool();

// Use the tool to switch chain context
const result = await setChainContextTool.call({ prompt: "Switch to AssetHub" });
console.log(result.content); // Output: Current chain context set to AssetHub
```



