### PR TITLE
fix: integration tests 

### DIFF
--- a/packages/common/src/chains/supportedChains.ts
+++ b/packages/common/src/chains/supportedChains.ts
@@ -40,7 +40,7 @@ export const westendChain = createChain({
   id: "west",
   name: "Westend",
   specName: "westend",
-  wsUrls: ["wss://westend-rpc.polkadot.io"],
+  wsUrls: ["wss://westend-rpc.polkadot.io","wss://westend-rpc.n.dwellir.com"],
   relay: "west",
   type: "relay",
   chainId: 0,

--- a/packages/common/src/chains/supportedChains.ts
+++ b/packages/common/src/chains/supportedChains.ts
@@ -40,7 +40,7 @@ export const westendChain = createChain({
   id: "west",
   name: "Westend",
   specName: "westend",
-  wsUrls: ["wss://westend-rpc.polkadot.io","wss://westend-rpc.n.dwellir.com"],
+  wsUrls: ["wss://westend-rpc.polkadot.io", "wss://westend-rpc.n.dwellir.com"],
   relay: "west",
   type: "relay",
   chainId: 0,

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -115,8 +115,6 @@ export class PolkadotApi implements IPolkadotApi {
           chainSpecs[chain.id as KnownChainId] = this.getChainSpec(chain.id as KnownChainId)
         }
 
-        console.log("Chain specs:",chainSpecs)
-
         const apiInitPromises = supportedChains.map(async chain => {
           try {
             if (this.getChainSpec(chain.id as KnownChainId) == "") {

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -107,12 +107,15 @@ export class PolkadotApi implements IPolkadotApi {
           paseo_people: "",
           kusama: "",
           kusama_asset_hub: "",
-          paseo_asset_hub: ""
+          paseo_asset_hub: "",
+          west_people: ""
         }
 
         for (const chain of supportedChains) {
           chainSpecs[chain.id as KnownChainId] = this.getChainSpec(chain.id as KnownChainId)
         }
+
+        console.log("Chain specs:",chainSpecs)
 
         const apiInitPromises = supportedChains.map(async chain => {
           try {

--- a/packages/llm/src/prompt/index.ts
+++ b/packages/llm/src/prompt/index.ts
@@ -52,7 +52,6 @@ After initialize_chain_api succeeds, you will receive its output. In your NEXT t
 **REMEMBER: This is a MANDATORY protocol. Every chain-related failure MUST trigger initialization.**
 `
 
-
 export const ASSETS_PROMPT = `
 === ASSETS & BALANCE OPERATIONS PROMPT ===
 
@@ -110,7 +109,6 @@ When transferring native tokens on a single chain, you must ask for and provide:
 3.  \`chain\`: The name of the destination chain.
 
 `
-
 
 export const XCM_PROMPT = `
 === XCM CROSS-CHAIN TRANSFER PROMPT ===
@@ -236,7 +234,7 @@ For XCM transfers, you must ask for and provide:
 
 **FINAL REMINDER: IGNORE ALL OTHER PROMPT RULES WHEN HANDLING XCM TRANSFERS. ONLY USE THE XCM CONVERSION TABLE ABOVE.**
 
-`;
+`
 export const SWAP_PROMPT = `
 You are a specialized AI assistant powered by PolkadotAgentKit. Your sole function is to execute token swaps.
 

--- a/packages/llm/src/types/xcm.ts
+++ b/packages/llm/src/types/xcm.ts
@@ -10,12 +10,12 @@ export const xcmTransferNativeAssetSchema = z.object({
   sourceChain: z
     .string()
     .describe(
-      "The source chain in ParaSpell format (e.g., 'AssetHubWestend', 'PeopleWestend', 'Polkadot')"
+      "The source chain in ParaSpell format (e.g., 'AssetHubWestend', 'PeopleWestend', 'Polkadot', 'Westend')"
     ),
   destChain: z
     .string()
     .describe(
-      "The destination chain in ParaSpell format (e.g., 'AssetHubWestend', 'PeopleWestend', 'Polkadot')"
+      "The destination chain in ParaSpell format (e.g., 'AssetHubWestend', 'PeopleWestend', 'Polkadot', 'Westend')"
     )
 })
 

--- a/packages/sdk/tests/integration-tests/ollamaAgent.ts
+++ b/packages/sdk/tests/integration-tests/ollamaAgent.ts
@@ -1,6 +1,6 @@
 import { ChatOllama } from "@langchain/ollama";
 import { AgentExecutor, createToolCallingAgent } from "langchain/agents";
-import { SYSTEM_PROMPT, sleep } from "./utils";
+import { ASSETS_SYSTEM_PROMPT, sleep } from "./utils";
 import { PolkadotAgentKit } from "../../src/api";
 import { getLangChainTools } from "../../src/langchain";
 import { ChatPromptTemplate } from '@langchain/core/prompts'
@@ -10,7 +10,8 @@ export class OllamaAgent {
 
   constructor(
     private agentKit: PolkadotAgentKit,
-    private model: string = "qwen3:latest"
+    private model: string = "qwen3:latest",
+    private systemPrompt: string = ASSETS_SYSTEM_PROMPT
   ) {}
 
   async init() {
@@ -24,12 +25,12 @@ export class OllamaAgent {
 
     const tools = getLangChainTools(this.agentKit);
 
-    // Use SYSTEM_PROMPT as the system message
+    // Use the provided system prompt
     const agentPrompt = createToolCallingAgent({
       llm: llm as any,
       tools: tools as any,
       prompt: ChatPromptTemplate.fromMessages([
-        ['system', SYSTEM_PROMPT],
+        ['system', this.systemPrompt],
         ['placeholder', '{chat_history}'],
         ['human', '{input}'],
         ['placeholder', '{agent_scratchpad}']

--- a/packages/sdk/tests/integration-tests/sdk.itest.ts
+++ b/packages/sdk/tests/integration-tests/sdk.itest.ts
@@ -155,7 +155,7 @@ describe('PolkadotAgentKit Integration with OllamaAgent for XCM Transfer', () =>
       agentKit = new PolkadotAgentKit({ 
         privateKey: process.env.AGENT_PRIVATE_KEY, 
         keyType: 'Sr25519', 
-        chains: ['west', 'west_asset_hub', 'paseo', 'paseo_asset_hub']
+        chains: ['west', 'west_people', 'paseo', 'paseo_asset_hub', 'west_asset_hub' ]
       });
       await agentKit.initializeApi();
 
@@ -309,20 +309,20 @@ describe('PolkadotAgentKit Integration with OllamaAgent for XCM Transfer', () =>
     });
   });
 
-  // describe('3. Parachain to Parachain Transfers', () => {
-  //   it('should call xcm_transfer_native_asset tool for "West Asset Hub to West People Chain"', async () => {
-  //     await testXcmTransfer(
-  //       'West Asset Hub to West People Chain',
-  //       `transfer 0.2 WND to ${RECIPIENT6} from AssetHubWestend to PeopleWestend via XCM`,
-  //       RECIPIENT6,
-  //       'west_asset_hub',
-  //       'west_people',
-  //       'AssetHubWestend',
-  //       'PeopleWestend',
-  //       '0.2'
-  //     );
-  //   }, 3500000);
-  // });
+  describe('3. Parachain to Parachain Transfers', () => {
+    it('should call xcm_transfer_native_asset tool for "West Asset Hub to West People Chain"', async () => {
+      await testXcmTransfer(
+        'West Asset Hub to West People Chain',
+        `transfer 0.2 WND to ${RECIPIENT6} from AssetHubWestend to PeopleWestend via XCM`,
+        RECIPIENT6,
+        'west_asset_hub',
+        'west_people',
+        'AssetHubWestend',
+        'PeopleWestend',
+        '0.2'
+      );
+    }, 3500000);
+  });
 
 })
 

--- a/packages/sdk/tests/integration-tests/sdk.itest.ts
+++ b/packages/sdk/tests/integration-tests/sdk.itest.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import { PolkadotAgentKit } from '../../src/api';
 import { RECIPIENT, sleep, getBalance, estimateTransactionFee, RECIPIENT2, RECIPIENT3, RECIPIENT4, RECIPIENT5, XCM_SYSTEM_PROMPT, RECIPIENT6, RECIPIENT0 } from './utils';
 import { OllamaAgent } from './ollamaAgent';
@@ -24,7 +24,7 @@ describe('PolkadotAgentKit Integration with OllamaAgent check balance', () => {
       agentKit = new PolkadotAgentKit({
         privateKey: process.env.AGENT_PRIVATE_KEY,
         keyType: 'Sr25519',
-        chains: ['west', 'west_asset_hub', 'paseo', 'paseo_asset_hub']
+        chains: ['west', 'west_asset_hub', 'paseo', 'paseo_asset_hub','west_people']
       });
       await agentKit.initializeApi();
 

--- a/packages/sdk/tests/integration-tests/sdk.itest.ts
+++ b/packages/sdk/tests/integration-tests/sdk.itest.ts
@@ -155,7 +155,7 @@ describe('PolkadotAgentKit Integration with OllamaAgent for XCM Transfer', () =>
       agentKit = new PolkadotAgentKit({ 
         privateKey: process.env.AGENT_PRIVATE_KEY, 
         keyType: 'Sr25519', 
-        chains: ['west', 'west_asset_hub', 'west_people', 'paseo', 'paseo_asset_hub']
+        chains: ['west', 'west_asset_hub', 'paseo', 'paseo_asset_hub']
       });
       await agentKit.initializeApi();
 
@@ -309,20 +309,20 @@ describe('PolkadotAgentKit Integration with OllamaAgent for XCM Transfer', () =>
     });
   });
 
-  describe('3. Parachain to Parachain Transfers', () => {
-    it('should call xcm_transfer_native_asset tool for "West Asset Hub to West People Chain"', async () => {
-      await testXcmTransfer(
-        'West Asset Hub to West People Chain',
-        `transfer 0.2 WND to ${RECIPIENT6} from AssetHubWestend to PeopleWestend via XCM`,
-        RECIPIENT6,
-        'west_asset_hub',
-        'west_people',
-        'AssetHubWestend',
-        'PeopleWestend',
-        '0.2'
-      );
-    }, 3500000);
-  });
+  // describe('3. Parachain to Parachain Transfers', () => {
+  //   it('should call xcm_transfer_native_asset tool for "West Asset Hub to West People Chain"', async () => {
+  //     await testXcmTransfer(
+  //       'West Asset Hub to West People Chain',
+  //       `transfer 0.2 WND to ${RECIPIENT6} from AssetHubWestend to PeopleWestend via XCM`,
+  //       RECIPIENT6,
+  //       'west_asset_hub',
+  //       'west_people',
+  //       'AssetHubWestend',
+  //       'PeopleWestend',
+  //       '0.2'
+  //     );
+  //   }, 3500000);
+  // });
 
 })
 

--- a/packages/sdk/tests/integration-tests/sdk.itest.ts
+++ b/packages/sdk/tests/integration-tests/sdk.itest.ts
@@ -1,225 +1,329 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { PolkadotAgentKit } from '../../src/api';
-import { RECIPIENT, sleep, getBalance, estimateTransactionFee, RECIPIENT2, RECIPIENT3, RECIPIENT4 } from './utils';
+import { RECIPIENT, sleep, getBalance, estimateTransactionFee, RECIPIENT2, RECIPIENT3, RECIPIENT4, RECIPIENT5, XCM_SYSTEM_PROMPT, RECIPIENT6, RECIPIENT0 } from './utils';
 import { OllamaAgent } from './ollamaAgent';
 import { estimateXcmFee, transferNativeCall } from '@polkadot-agent-kit/core';
 import { parseUnits, getDecimalsByChainId } from '@polkadot-agent-kit/common';
 import dotenv from 'dotenv';
+import { ASSETS_PROMPT } from '@polkadot-agent-kit/llm';
 dotenv.config({ path: '../../.env' });
-let agentKit: PolkadotAgentKit;
-let ollamaAgent: OllamaAgent;
 
-beforeAll(async () => {
 
-  // Make sure private key 
-  if (process.env.AGENT_PRIVATE_KEY) {
-  agentKit = new PolkadotAgentKit( { privateKey: process.env.AGENT_PRIVATE_KEY,  keyType: 'Sr25519', chains: ['paseo','west', 'west_asset_hub', 'west_people'] });
-    await agentKit.initializeApi();
-    ollamaAgent = new OllamaAgent(agentKit);
-    await ollamaAgent.init();
-  } else {
-    throw new Error('AGENT_PRIVATE_KEY is not set');
-  }
-}, 1500000);
-
-afterAll(async () => {
-  await agentKit.disconnect();
-});
 
 /// Note: 
 /// We are using Ollama for testing purposes, but you can use any other model you want
-/// We are using Westend and Westend Asset Hub for integrations tests 
-describe('PolkadotAgentKit Integration with OllamaAgent', () => {
-  it('should call check_balance tool with correct chain parameter', async () => {
-    const result = await ollamaAgent.ask('check balance on Paseo');
-    
-    expect(result.output).toBeDefined();
-    expect(result.intermediateSteps).toBeDefined();
-    expect(result.intermediateSteps.length).toBeGreaterThan(0);
-    
-    const balanceCall = result.intermediateSteps.find((step: any) => 
-      step.action?.tool === 'check_balance'
+
+
+describe('PolkadotAgentKit Integration with OllamaAgent check balance', () => {
+  let agentKit: PolkadotAgentKit;
+  let ollamaAgent: OllamaAgent;
+
+  beforeAll(async () => {
+    // Make sure private key 
+    if (process.env.AGENT_PRIVATE_KEY) {
+      agentKit = new PolkadotAgentKit({
+        privateKey: process.env.AGENT_PRIVATE_KEY,
+        keyType: 'Sr25519',
+        chains: ['west', 'west_asset_hub', 'paseo', 'paseo_asset_hub']
+      });
+      await agentKit.initializeApi();
+
+
+      ollamaAgent = new OllamaAgent(agentKit, "qwen3:latest", ASSETS_PROMPT);
+      await ollamaAgent.init();
+
+      console.log('🏗️ Assets Agent initialized with ASSETS_PROMPT');
+    } else {
+      throw new Error('AGENT_PRIVATE_KEY is not set');
+    }
+  }, 3500000);
+
+  describe('Check balance on Westend with different users intent ', () => {
+    const testCases = [
+      { query: 'check balance on paseo', expectedChain: 'paseo' },
+      { query: 'check balance on Paseo Asset Hub', expectedChain: 'paseo_asset_hub' },
+      { query: 'check balance on Asset Hub Paseo', expectedChain: 'paseo_asset_hub' },
+    ];
+
+    it.each(testCases)(
+      'should call check_balance tool with correct chain for "$query"',
+      async ({ query, expectedChain }) => {
+        const result = await ollamaAgent.ask(query);
+
+        expect(result.output).toBeDefined();
+        expect(result.intermediateSteps).toBeDefined();
+        expect(result.intermediateSteps.length).toBeGreaterThan(0);
+
+        const balanceCall = result.intermediateSteps.find(
+          (step: any) => step.action?.tool === 'check_balance'
+        );
+
+        expect(balanceCall).toBeDefined();
+        expect(balanceCall.action.toolInput).toEqual({
+          chain: expectedChain,
+        });
+
+        await sleep(30000);
+      },
+      3500000
     );
-    
-    expect(balanceCall).toBeDefined();
-    expect(balanceCall.action.toolInput).toEqual({
-      chain: 'paseo'  
+  });
+
+})
+
+describe('PolkadotAgentKit Integration with OllamaAgent transfer_native tool', () => {
+  let agentKit: PolkadotAgentKit;
+  let ollamaAgent: OllamaAgent;
+
+  beforeAll(async () => {
+    // Make sure private key 
+    if (process.env.AGENT_PRIVATE_KEY) {
+      agentKit = new PolkadotAgentKit({
+        privateKey: process.env.AGENT_PRIVATE_KEY,
+        keyType: 'Sr25519',
+        chains: ['west']
+      });
+      await agentKit.initializeApi();
+
+
+      ollamaAgent = new OllamaAgent(agentKit, "qwen3:latest", ASSETS_PROMPT);
+      await ollamaAgent.init();
+
+      console.log('🏗️ Assets Agent initialized with ASSETS_PROMPT');
+    } else {
+      throw new Error('AGENT_PRIVATE_KEY is not set');
+    }
+  }, 3500000);
+
+  describe('Should call transfer_native tool', () => {
+
+    const testCases = [
+      `transfer 0.001 WND to ${RECIPIENT0} on Westend Relay Chain`,
+    ];
+
+    it.each(testCases)('should call transfer_native tool with correct parameters for query: "%s"', async (userQuery) => {
+      const balanceRecipientBefore = await getBalance(agentKit.getApi('west'), RECIPIENT0);
+      const balanceAgentBefore = await getBalance(agentKit.getApi('west'), agentKit.getCurrentAddress());
+      const result = await ollamaAgent.ask(userQuery);
+      console.log('Transfer Query Result:', result);
+
+
+      const amount = parseUnits("0.001", getDecimalsByChainId('west'));
+
+      const tx = await transferNativeCall(agentKit.getApi('west'), agentKit.getCurrentAddress(), RECIPIENT0, amount);
+
+      const feeTx = await estimateTransactionFee(tx.transaction!, RECIPIENT0);
+      expect(result.output).toBeDefined();
+      expect(result.intermediateSteps).toBeDefined();
+      expect(result.intermediateSteps.length).toBeGreaterThan(0);
+
+      const transferCall = result.intermediateSteps.find((step: any) =>
+        step.action?.tool === 'transfer_native'
+      );
+
+      expect(transferCall).toBeDefined();
+      expect(transferCall.action.toolInput).toMatchObject({
+        amount: '0.001',
+        chain: 'west',
+        to: RECIPIENT0,
+      });
+
+      await sleep(30000);
+
+      const balanceRecipientAfter = await getBalance(agentKit.getApi('west'), RECIPIENT0);
+      expect(balanceRecipientAfter.data.free).toEqual(balanceRecipientBefore.data.free + amount);
+
+      const balanceAgentAfter = await getBalance(agentKit.getApi('west'), agentKit.getCurrentAddress());
+      expect(balanceAgentAfter.data.free).toBeLessThan(balanceAgentBefore.data.free - amount - feeTx);
+
+    }, 3500000);
+
+
+  })
+
+})
+
+
+
+describe('PolkadotAgentKit Integration with OllamaAgent for XCM Transfer', () => {
+  let agentKit: PolkadotAgentKit;  
+  let ollamaAgent: OllamaAgent;    
+
+  beforeAll(async () => {
+    // Make sure private key 
+    if (process.env.AGENT_PRIVATE_KEY) {
+      agentKit = new PolkadotAgentKit({ 
+        privateKey: process.env.AGENT_PRIVATE_KEY, 
+        keyType: 'Sr25519', 
+        chains: ['west', 'west_asset_hub', 'west_people', 'paseo', 'paseo_asset_hub']
+      });
+      await agentKit.initializeApi();
+
+      ollamaAgent = new OllamaAgent(agentKit, "qwen3:latest", XCM_SYSTEM_PROMPT);
+      await ollamaAgent.init();
+      
+    } else {
+      throw new Error('AGENT_PRIVATE_KEY is not set');
+    }
+  }, 3500000);
+
+  afterEach(async () => {
+
+    await sleep(30000); // 30 seconds delay
+  });
+
+  // Helper function to test XCM transfer variations
+  const testXcmTransfer = async (
+    testName: string,
+    userQuery: string,
+    recipient: string,
+    sourceChainId: any,
+    destChainId: any,
+    expectedSourceChain: string,
+    expectedDestChain: string,
+    amount: string = "0.1"
+  ) => {
+    const balanceAgentBefore = await getBalance(agentKit.getApi(sourceChainId), agentKit.getCurrentAddress());
+    const balanceRecipientBefore = await getBalance(agentKit.getApi(destChainId), recipient);
+    const amountParsed = parseUnits(amount, getDecimalsByChainId(sourceChainId));
+
+      const result = await ollamaAgent.ask(userQuery);
+      console.log(`XCM Transfer Query Result (${testName}):`, result);
+
+      expect(result.output).toBeDefined();
+      expect(result.intermediateSteps).toBeDefined();
+      expect(result.intermediateSteps.length).toBeGreaterThan(0);
+
+      const xcmTransferCall = result.intermediateSteps.find((step: any) =>
+        step.action?.tool === 'xcm_transfer_native_asset'
+      );
+
+      expect(xcmTransferCall).toBeDefined();
+      expect(xcmTransferCall.action.toolInput).toMatchObject({
+      amount: amount,
+        to: recipient,
+        sourceChain: expectedSourceChain,
+        destChain: expectedDestChain
+      });
+
+      await sleep(3 * 60 * 1000); // 3 minutes
+    const balanceRecipientAfter = await getBalance(agentKit.getApi(destChainId), recipient);
+    expect(balanceRecipientAfter.data.free).toBeLessThan(balanceRecipientBefore.data.free + amountParsed);
+
+    const balanceAgentAfter = await getBalance(agentKit.getApi(sourceChainId), agentKit.getCurrentAddress());
+    const feeXCM = await estimateXcmFee(expectedSourceChain, agentKit.getCurrentAddress(), expectedDestChain, recipient, amountParsed.toString());
+    expect(balanceAgentAfter.data.free).toBeLessThan(balanceAgentBefore.data.free - amountParsed - feeXCM.fee);
+  };
+
+  describe('1. Relay Chain to Parachain Transfers', () => {
+    const relayToParachainCases = [
+      {
+        name: 'from Westend to Asset Hub Westend',
+        query: `transfer 0.1 WND to ${RECIPIENT} from Westend to Asset Hub Westend`,
+        recipient: RECIPIENT,
+        sourceChainId: 'west',
+        destChainId: 'west_asset_hub',
+        expectedSourceChain: 'Westend',
+        expectedDestChain: 'AssetHubWestend'
+      },
+      {
+        name: 'from Westend to Asset Hub West',
+        query: `transfer 0.1 WND to ${RECIPIENT2} from Westend to Asset Hub West`,
+        recipient: RECIPIENT2,
+        sourceChainId: 'west',
+        destChainId: 'west_asset_hub',
+        expectedSourceChain: 'Westend',
+        expectedDestChain: 'AssetHubWestend'
+      },
+      {
+        name: 'from Westend to Westend\'s Asset Hub',
+        query: `transfer 0.1 WND to ${RECIPIENT3} from Westend to Westend's Asset Hub`,
+        recipient: RECIPIENT3,
+        sourceChainId: 'west',
+        destChainId: 'west_asset_hub',
+        expectedSourceChain: 'Westend',
+        expectedDestChain: 'AssetHubWestend'
+      },
+      {
+        name: 'from Westend\'s relay chain to Westend\'s Asset Hub',
+        query: `transfer 0.1 WND to ${RECIPIENT4} from Westend's relay chain to Westend's Asset Hub`,
+        recipient: RECIPIENT4,
+        sourceChainId: 'west',
+        destChainId: 'west_asset_hub',
+        expectedSourceChain: 'Westend',
+        expectedDestChain: 'AssetHubWestend'
+      },
+      {
+        name: 'from West to Asset Hub West',
+        query: `transfer 0.1 WND to ${RECIPIENT5} from West to Westend Asset Hub`,
+        recipient: RECIPIENT5,
+        sourceChainId: 'west',
+        destChainId: 'west_asset_hub',
+        expectedSourceChain: 'Westend',
+        expectedDestChain: 'AssetHubWestend'
+      },
+      {
+        name: 'from West to West Asset Hub',
+        query: `transfer 0.1 WND to ${RECIPIENT6} from West to West Asset Hub`,
+        recipient: RECIPIENT6,
+        sourceChainId: 'west',
+        destChainId: 'west_asset_hub',
+        expectedSourceChain: 'Westend',
+        expectedDestChain: 'AssetHubWestend'
+      }
+    ];
+
+    relayToParachainCases.forEach(({ name, query, recipient, sourceChainId, destChainId, expectedSourceChain, expectedDestChain }) => {
+      it(`should call xcm_transfer_native_asset tool for "${name}"`, async () => {
+        await testXcmTransfer(name, query, recipient, sourceChainId, destChainId, expectedSourceChain, expectedDestChain);
+      }, 3500000);
     });
-    
-    await sleep(30000);
-  }, 1500000); 
+  });
 
-  it('should call transfer_native tool with correct parameters', async () => {
-    const userQuery = `transfer 0.001 WND to ${RECIPIENT} on Westend`;
-    const balanceRecipientBefore = await getBalance(agentKit.getApi('west'), RECIPIENT);
-    const balanceAgentBefore = await getBalance(agentKit.getApi('west'), agentKit.getCurrentAddress());
-    const result = await ollamaAgent.ask(userQuery);
-    console.log('Transfer Query Result:', result);
+  describe('2. Parachain to Relay Chain Transfers', () => {
+    const parachainToRelayCases = [
+      {
+        name: 'Paseo Asset Hub to Paseo',
+        query: `transfer 0.1 WND to ${RECIPIENT2} from Paseo Asset Hub to Paseo`,
+        recipient: RECIPIENT2,
+        sourceChainId: 'paseo_asset_hub',
+        destChainId: 'paseo',
+        expectedSourceChain: 'AssetHubPaseo',
+        expectedDestChain: 'Paseo'
+      },
+      {
+        name: 'Paseo Asset Hub to Paseo',
+        query: `transfer 0.1 WND to ${RECIPIENT3} from Asset Hub Paseo to Paseo`,
+        recipient: RECIPIENT3,
+        sourceChainId: 'paseo_asset_hub',
+        destChainId: 'paseo',
+        expectedSourceChain: 'AssetHubPaseo',
+        expectedDestChain: 'Paseo'
+      }
+    ];
 
-
-    const amount = parseUnits("0.001", getDecimalsByChainId('west'));
-
-   const tx =  await transferNativeCall(agentKit.getApi('west'), agentKit.getCurrentAddress(), RECIPIENT, amount);
-
-    const feeTx = await estimateTransactionFee(tx.transaction!, RECIPIENT);
-    expect(result.output).toBeDefined();
-    expect(result.intermediateSteps).toBeDefined();
-    expect(result.intermediateSteps.length).toBeGreaterThan(0);
-    
-    const transferCall = result.intermediateSteps.find((step: any) => 
-      step.action?.tool === 'transfer_native'
-    );
-    
-    expect(transferCall).toBeDefined();
-    expect(transferCall.action.toolInput).toMatchObject({
-      amount: '0.001',
-      chain: 'west',
-      to: RECIPIENT,
+    parachainToRelayCases.forEach(({ name, query, recipient, sourceChainId, destChainId, expectedSourceChain, expectedDestChain }) => {
+      it(`should call xcm_transfer_native_asset tool for "${name}"`, async () => {
+        await testXcmTransfer(name, query, recipient, sourceChainId, destChainId, expectedSourceChain, expectedDestChain);
+      }, 3500000);
     });
-    
-    await sleep(30000);
+  });
 
-    const balanceRecipientAfter = await getBalance(agentKit.getApi('west'), RECIPIENT);
-    expect(balanceRecipientAfter.data.free).toEqual(balanceRecipientBefore.data.free + amount);
+  describe('3. Parachain to Parachain Transfers', () => {
+    it('should call xcm_transfer_native_asset tool for "West Asset Hub to West People Chain"', async () => {
+      await testXcmTransfer(
+        'West Asset Hub to West People Chain',
+        `transfer 0.2 WND to ${RECIPIENT6} from AssetHubWestend to PeopleWestend via XCM`,
+        RECIPIENT6,
+        'west_asset_hub',
+        'west_people',
+        'AssetHubWestend',
+        'PeopleWestend',
+        '0.2'
+      );
+    }, 3500000);
+  });
 
-    const balanceAgentAfter = await getBalance(agentKit.getApi('west'), agentKit.getCurrentAddress());
-    expect(balanceAgentAfter.data.free).toBeLessThan(balanceAgentBefore.data.free - amount - feeTx);
-
-  }, 1500000); 
-
-  it('should call xcm_transfer_native_asset tool for Westend to Asset Hub transfer', async () => {
-    const userQuery = `transfer 0.1 WND to ${RECIPIENT2} from Westend to Asset Hub`;
-
-    const balanceAgentBefore = await getBalance(agentKit.getApi('west'), agentKit.getCurrentAddress());
-    // Get balance Recipient Before on Westend Asset Hub
-    const balanceRecipientBefore = await getBalance(agentKit.getApi('west_asset_hub'), RECIPIENT2);
-
-    const amount = parseUnits("0.1", getDecimalsByChainId('west'));
-
-    const result = await ollamaAgent.ask(userQuery);
-    console.log('XCM Transfer Query Result (Westend → Asset Hub):', result);
-    
-    expect(result.output).toBeDefined();
-    expect(result.intermediateSteps).toBeDefined();
-    expect(result.intermediateSteps.length).toBeGreaterThan(0);
-    
-    const xcmTransferCall = result.intermediateSteps.find((step: any) => 
-      step.action?.tool === 'xcm_transfer_native_asset'
-    );
-    
-    expect(xcmTransferCall).toBeDefined();
-    expect(xcmTransferCall.action.toolInput).toMatchObject({
-      amount: '0.1',
-      to: RECIPIENT2,
-      sourceChain: 'Westend',
-      destChain: 'AssetHubWestend'
-    });
-
-    await sleep(3 * 60 * 1000); // 3 minutes
-    // Note: make sure get balance on destination chain about 2-3 mins to get the latest balance update
-    const balanceRecipientAfter = await getBalance(agentKit.getApi('west_asset_hub'), RECIPIENT2);
-    // Noted: cant compare equal due to deposit assets on destination chain 
-    expect(balanceRecipientAfter.data.free).toBeLessThan(balanceRecipientBefore.data.free + amount);
-
-    const balanceAgentAfter = await getBalance(agentKit.getApi('west'), agentKit.getCurrentAddress());
-    const feeXCM = await estimateXcmFee('Westend', agentKit.getCurrentAddress(), 'AssetHubWestend', RECIPIENT2, amount.toString());
-
-    // after < before - amount - fee XCM estimate on source chain
-    expect(balanceAgentAfter.data.free).toBeLessThan(balanceAgentBefore.data.free - amount - feeXCM.fee);
-
-  }, 1500000); 
-
-  it('should call xcm_transfer_native_asset tool for Asset Hub to Westend transfer', async () => {
-    const userQuery = `transfer 0.1 WND to ${RECIPIENT3} from Asset Hub to Westend`;
-    
-    // Get balances before transfer
-    const balanceAgentBefore = await getBalance(agentKit.getApi('west_asset_hub'), agentKit.getCurrentAddress());
-    const balanceRecipientBefore = await getBalance(agentKit.getApi('west'), RECIPIENT3);
-    
-    const amount = parseUnits("0.1", getDecimalsByChainId('west_asset_hub'));
-    console.log("Amount Here:", amount);
-    
-    const result = await ollamaAgent.ask(userQuery);
-    console.log('XCM Transfer Query Result (Asset Hub → Westend):', result);
-    
-    expect(result.output).toBeDefined();
-    expect(result.intermediateSteps).toBeDefined();
-    expect(result.intermediateSteps.length).toBeGreaterThan(0);
-    
-    const xcmTransferCall = result.intermediateSteps.find((step: any) => 
-      step.action?.tool === 'xcm_transfer_native_asset'
-    );
-    
-    expect(xcmTransferCall).toBeDefined();
-    expect(xcmTransferCall.action.toolInput).toMatchObject({
-      amount: '0.1',
-      to: RECIPIENT3,
-      sourceChain: 'AssetHubWestend',
-      destChain: 'Westend'
-    });
-    
-    await sleep(3 * 60 * 1000); // 3 minutes
-    // Note: make sure get balance on destination chain about 2-3 mins to get the latest balance update
-    
-    // Check recipient balance on destination chain (Westend)
-    const balanceRecipientAfter = await getBalance(agentKit.getApi('west'), RECIPIENT3);
-    // Noted: cant compare equal due to deposit assets on destination chain 
-    expect(balanceRecipientAfter.data.free).toBeLessThan(balanceRecipientBefore.data.free + amount);
-
-    // Check agent balance on source chain (Asset Hub)
-    const balanceAgentAfter = await getBalance(agentKit.getApi('west_asset_hub'), agentKit.getCurrentAddress());
-    const feeXCM = await estimateXcmFee('AssetHubWestend', agentKit.getCurrentAddress(), 'Westend', RECIPIENT3, amount.toString());
-
-    // after < before - amount - fee XCM estimate on source chain
-    expect(balanceAgentAfter.data.free).toBeLessThan(balanceAgentBefore.data.free - amount - feeXCM.fee);
-    
-  }, 1500000);
-
-  it('should call xcm_transfer_native_asset tool for West Asset Hub to West People Chain transfer', async () => {
-
-    const userQuery = `transfer 0.2 WND to ${RECIPIENT4} from AssetHubWestend to PeopleWestend via XCM`;
-    
-    // Get balances before transfer
-    const balanceAgentBefore = await getBalance(agentKit.getApi('west_asset_hub'), agentKit.getCurrentAddress());
-    const balanceRecipientBefore = await getBalance(agentKit.getApi('west_people'), RECIPIENT4);
-    
-    const amount = parseUnits("0.2", getDecimalsByChainId('west_asset_hub'));
-    
-    const result = await ollamaAgent.ask(userQuery);
-    console.log('XCM Transfer Query Result (West Asset Hub → West People Chain):', result);
-    
-    expect(result.output).toBeDefined();
-    expect(result.intermediateSteps).toBeDefined();
-    expect(result.intermediateSteps.length).toBeGreaterThan(0);
-    
-    const xcmTransferCall = result.intermediateSteps.find((step: any) => 
-      step.action?.tool === 'xcm_transfer_native_asset'
-    );
-    
-    expect(xcmTransferCall).toBeDefined();
-    expect(xcmTransferCall.action.toolInput).toMatchObject({
-      amount: '0.2',
-      to: RECIPIENT4,
-      sourceChain: 'AssetHubWestend',  
-      destChain: 'PeopleWestend'      
-    });
-    
-    await sleep(3 * 60 * 1000); // 3 minutes
-    // Note: make sure get balance on destination chain about 2-3 mins to get the latest balance update
-    
-    // Check recipient balance on destination chain (PeopleWestend)
-    const balanceRecipientAfter = await getBalance(agentKit.getApi('west_people'), RECIPIENT4);
-    // Noted: cant compare equal due to deposit assets on destination chain 
-    expect(balanceRecipientAfter.data.free).toBeLessThan(balanceRecipientBefore.data.free + amount);
-
-    // Check agent balance on source chain (Asset Hub)
-    const balanceAgentAfter = await getBalance(agentKit.getApi('west_asset_hub'), agentKit.getCurrentAddress());
-    const feeXCM = await estimateXcmFee('AssetHubWestend', agentKit.getCurrentAddress(), 'PeopleWestend', RECIPIENT4, amount.toString());
-
-    // after < before - amount - fee XCM estimate on source chain
-    expect(balanceAgentAfter.data.free).toBeLessThan(balanceAgentBefore.data.free - amount - feeXCM.fee);
-    
-  }, 1500000);
+})
 
 
-});

--- a/packages/sdk/tests/integration-tests/utils.ts
+++ b/packages/sdk/tests/integration-tests/utils.ts
@@ -1,12 +1,55 @@
 import type { Api, KnownChainId } from "@polkadot-agent-kit/common"
-import {ASSETS_PROMPT, SWAP_PROMPT, NOMINATION_PROMPT, IDENTITY_PROMPT, BIFROST_PROMPT} from "@polkadot-agent-kit/llm"
-
+import {ASSETS_PROMPT, XCM_PROMPT, SWAP_PROMPT, NOMINATION_PROMPT, IDENTITY_PROMPT, BIFROST_PROMPT} from "@polkadot-agent-kit/llm"
+import { OllamaAgent } from './ollamaAgent';
 import { UnsafeTransactionType } from "@polkadot-agent-kit/common"
+import { PolkadotAgentKit } from "../../src/api";
+export const RECIPIENT0 = '5Fniv36Eu3bTWVRaR6N2Ve1qVouiTd15SJcZpxPyhkngRnqj';
 export const RECIPIENT= '5CcqKCNDxrYYkPNWys8yrjHJVTzd69i66VTgtewrSbJiVqoR';
 export const RECIPIENT2 = '5D7jcv6aYbhbYGVY8k65oemM6FVNoyBfoVkuJ5cbFvbefftr';
 export const RECIPIENT3 = '5FdxcDTshU5yhHrC91NneaJ64XCE2jwxnMCv8bfxQbwhkWMG';
 export const RECIPIENT4 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
-export const SYSTEM_PROMPT = ASSETS_PROMPT + SWAP_PROMPT + NOMINATION_PROMPT + IDENTITY_PROMPT + BIFROST_PROMPT;
+export const RECIPIENT5 = '5Ccmxb84eREZmtSkrLJSYp6QxJwNvmNbrfBm4p5B5VnKrB8z';
+export const RECIPIENT6 = '5DNsfcAFhDMXesUwwXdBqfqPe9AHsZ5mWEnmoKq2sPMDg9re';
+
+
+
+const XCM_ONLY_CONTEXT = `
+=== XCM TRANSFER SPECIALIST ===
+You are a specialized agent for XCM cross-chain transfers ONLY.
+
+**EXCLUSIVE CHAIN NAME RULES FOR XCM:**
+- "West" → "Westend" 
+- "Westend" → "Westend"
+- "West Asset Hub" → "AssetHubWestend"
+- "Westend Asset Hub" → "AssetHubWestend"
+- "Asset Hub West" → "AssetHubWestend"
+
+**TOOL**: xcm_transfer_native_asset
+**FORMAT**: ParaSpell (PascalCase)
+**TRIGGER**: "from X to Y" pattern
+
+` + XCM_PROMPT;
+
+
+const ASSETS_ONLY_CONTEXT = `
+=== BALANCE & NATIVE TRANSFER SPECIALIST ===
+You are a specialized agent for balance checks and native transfers ONLY.
+
+**EXCLUSIVE CHAIN NAME RULES FOR ASSETS:**
+- "West" → "west"
+- "Westend" → "west" 
+- "West Asset Hub" → "west_asset_hub"
+- "Westend Asset Hub" → "west_asset_hub"
+
+**TOOLS**: check_balance, transfer_native
+**FORMAT**: Internal chain IDs (lowercase)
+**TRIGGER**: Single chain operations
+
+` + ASSETS_PROMPT;
+
+
+export const XCM_SYSTEM_PROMPT = XCM_ONLY_CONTEXT;
+export const ASSETS_SYSTEM_PROMPT = ASSETS_ONLY_CONTEXT;
 
 export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));

--- a/packages/sdk/tests/integration-tests/utils.ts
+++ b/packages/sdk/tests/integration-tests/utils.ts
@@ -1,8 +1,7 @@
 import type { Api, KnownChainId } from "@polkadot-agent-kit/common"
 import {ASSETS_PROMPT, XCM_PROMPT, SWAP_PROMPT, NOMINATION_PROMPT, IDENTITY_PROMPT, BIFROST_PROMPT} from "@polkadot-agent-kit/llm"
-import { OllamaAgent } from './ollamaAgent';
 import { UnsafeTransactionType } from "@polkadot-agent-kit/common"
-import { PolkadotAgentKit } from "../../src/api";
+
 export const RECIPIENT0 = '5Fniv36Eu3bTWVRaR6N2Ve1qVouiTd15SJcZpxPyhkngRnqj';
 export const RECIPIENT= '5CcqKCNDxrYYkPNWys8yrjHJVTzd69i66VTgtewrSbJiVqoR';
 export const RECIPIENT2 = '5D7jcv6aYbhbYGVY8k65oemM6FVNoyBfoVkuJ5cbFvbefftr';

--- a/packages/sdk/vitest.config.testnet.ts
+++ b/packages/sdk/vitest.config.testnet.ts
@@ -6,8 +6,8 @@ export default defineConfig({
     environment: 'node',
     include: ['./tests/integration-tests/sdk.itest.ts'],
     exclude: ['./tests/integration-tests/sdk.mainnet.itest.ts'],
-    testTimeout: 600000,
-    hookTimeout: 600000,
+    testTimeout: 3500000,
+    hookTimeout: 3500000,
     onConsoleLog: () => true,
   }
 })


### PR DESCRIPTION


Issue: The `qwen3:latest` model is incorrectly mapping chain IDs to names, ignoring/ conflicting the prompt's conversion rules and causing the tool call to fail

Our solution: Seperate the prompt for each tests case ( assets, xcm, staking, ...) 